### PR TITLE
add heco relayer

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -87,6 +87,14 @@ export const networks = {
         RelayHub: "0x63dd60b79cb8e3d2fa20a6d2ec92e101553a3920",
     },
 
+    heco: {
+        group:'HECO',
+        name: 'Huobi Eco Chain',
+        url: 'https://heco.mytokenpocket.vip',
+        etherscan: "https://hecoinfo.com/address/",
+        RelayHub: "0xDc87dE4AFFAaAE38d6875D5690cA2819E8D330c7"
+    }
+
     /*
         kovanBeta3:  {
             name: "Kovan-V2 beta.3",


### PR DESCRIPTION
Add heco(Huobi Eco Chain) GSN network entry for listing.
All contracts verified here:
[VersionRegistry](https://hecoinfo.com/address/0xd5e45840642d2A4c09Ea5203905FfEa081C3338E#code)   
[StakeManager](https://hecoinfo.com/address/0x08a5EB1281Cb322b2d3d9c528f2f8b53c9c26C4b#code)  
[Penalizer](https://hecoinfo.com/address/0x74aEDc6D42b5EBEf777E67E1A4dD6cCfD7B84083#code) 
[Forwarder](https://hecoinfo.com/address/0x384479d457c7dAA5E6B4E6b3Eb9F1BE91678D64F#code) 
[RelayHub](https://hecoinfo.com/address/0xDc87dE4AFFAaAE38d6875D5690cA2819E8D330c7#contracts) 